### PR TITLE
chore: add Zenodo DOI badge to README and DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Description: Utilities to convert an OpenAlex parquet/Arrow corpus into
     other formats. Implemented are at the moment CSL JSON, BibTeX, BibLaTeX,
     Markdown, LaTeX, HTML, or PDF via Pandoc. Uses DuckDB over Arrow for
     efficient chunked CSL JSON conversion. 
-URL: https://github.com/rkrug/openalexConvert, https://rkrug.github.io/openalexConvert/
+URL: https://github.com/rkrug/openalexConvert, https://rkrug.github.io/openalexConvert/, https://doi.org/10.5281/zenodo.20448988
 BugReports: https://github.com/rkrug/openalexConvert/issues
 License: GPL (>= 2)
 Depends:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.20448988.svg)](https://doi.org/10.5281/zenodo.20448988)
+
 # openalexConvert
 
 Convert an [OpenAlex](https://openalex.org) parquet corpus (produced by


### PR DESCRIPTION
Adds the concept DOI badge to README.md and DOI URL to DESCRIPTION.