### PR TITLE
chore: bump version to 0.0.3

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openalexConvert
 Title: Convert OpenAlex Parquet (from openalexPro) to other Formats
-Version: 0.0.2
+Version: 0.0.3
 Author: Rainer M Krug
 Maintainer: Rainer M Krug <Rainer@krugs.de>
 Description: Utilities to convert an OpenAlex parquet/Arrow corpus into

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,12 @@
-# openalexConvert (development version)
+# openalexConvert 0.0.3
 
 ## Bug fixes
 
+- `corpus_export_via_pandoc()`: now produces a single output file (e.g.
+  `corpus.bib`) as documented. Previously it passed the chunked CSL JSON
+  directory to `csljson_convert_pandoc()`, which created a *directory* of
+  per-chunk files at the `output` path, and it returned the wrong path when an
+  extension had to be appended.
 - `csljson_convert_pandoc()`: the `pdf_engine` parameter is now respected. Previously
   `--pdf-engine=xelatex` was unconditionally appended, overriding any user-specified
   engine (e.g. `"lualatex"` or `"pdflatex"`).
@@ -16,4 +21,6 @@
   `openalexPro` from r-universe automatically.
 - CI aligned with the rest of the openalexPro ecosystem: standard `R-CMD-check.yaml`
   (macOS, Windows, Ubuntu × devel/release/oldrel-1) and `test-coverage.yaml` added.
+- Test coverage raised to ~86%, with new tests for `corpus_export_via_pandoc()`,
+  Pandoc rendering paths, and `csljson_to_zotero_upload()`.
 - Leftover `_problems/` test artefacts from a previous failed run removed.


### PR DESCRIPTION
Bumps the package version `0.0.2 → 0.0.3` and converts the NEWS.md
"(development version)" section into a tagged `0.0.3` release entry.

## Changes
- `DESCRIPTION`: `Version: 0.0.3`
- `NEWS.md`: heading tagged as `0.0.3`; added entries for the
  `corpus_export_via_pandoc()` single-file fix and the test-coverage work
  (alongside the existing `pdf_engine`/DOI fixes already noted).

No code changes — content is identical to what already passed CI on `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)